### PR TITLE
Add code action key binding for nvim configs

### DIFF
--- a/neovim-init-lsp-compe-rust-tools.vim
+++ b/neovim-init-lsp-compe-rust-tools.vim
@@ -88,6 +88,9 @@ nnoremap <silent> gW    <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
 nnoremap <silent> gd    <cmd>lua vim.lsp.buf.definition()<CR>
 "nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
 
+" Quick-fix
+nnoremap <silent> ga    <cmd>lua vim.lsp.buf.code_action()<CR>
+
 " Completion
 lua <<EOF
 require'compe'.setup {

--- a/neovim-init-lsp-compe.vim
+++ b/neovim-init-lsp-compe.vim
@@ -82,6 +82,9 @@ nnoremap <silent> gW    <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
 nnoremap <silent> gd    <cmd>lua vim.lsp.buf.definition()<CR>
 "nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
 
+" Quick-fix
+nnoremap <silent> ga    <cmd>lua vim.lsp.buf.code_action()<CR>
+
 " Completion
 lua <<EOF
 require'compe'.setup {

--- a/neovim-init-lsp.vim
+++ b/neovim-init-lsp.vim
@@ -81,6 +81,9 @@ nnoremap <silent> gW    <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
 nnoremap <silent> gd    <cmd>lua vim.lsp.buf.definition()<CR>
 "nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
 
+" Quick-fix
+nnoremap <silent> ga    <cmd>lua vim.lsp.buf.code_action()<CR>
+
 " Trigger completion with <tab>
 " found in :help completion
 " Use <Tab> and <S-Tab> to navigate through popup menu


### PR DESCRIPTION
Add the code action key binding to the example configs.

The binding was mentioned on the [blog post](https://sharksforarms.dev/posts/neovim-rust/), and I found it to be useful.