### PR TITLE
Update neovim-init-lsp.vim

### DIFF
--- a/neovim-init-lsp.vim
+++ b/neovim-init-lsp.vim
@@ -22,9 +22,6 @@ Plug 'arcticicestudio/nord-vim'
 
 call plug#end()
 
-syntax enable
-filetype plugin indent on
-
 colorscheme nord
 
 


### PR DESCRIPTION
Remove syntax and filetype plugin indent because it's nvim defaults