### PR TITLE
Update neovim-init-lsp-cmp-rust-tools.vim

### DIFF
--- a/neovim-init-lsp-cmp-rust-tools.vim
+++ b/neovim-init-lsp-cmp-rust-tools.vim
@@ -38,9 +38,6 @@ Plug 'arcticicestudio/nord-vim'
 
 call plug#end()
 
-syntax enable
-filetype plugin indent on
-
 colorscheme nord
 
 


### PR DESCRIPTION
Remove syntax and filetype plugin indent because it's nvim defaults